### PR TITLE
add enum type

### DIFF
--- a/generate/swaggergen/g_docs.go
+++ b/generate/swaggergen/g_docs.go
@@ -785,22 +785,28 @@ func parserComments(fl *ast.File, f *ast.FuncDecl, controllerName, pkgpath strin
 					}
 					setParamType(&para, typ, fl, pkgpath, controllerName)
 				}
-				var paramDesc string
-				switch len(p) {
-				case 5:
-					para.Required, _ = strconv.ParseBool(p[3])
-					paramDesc = strings.Trim(p[4], `" `)
-				case 6:
-					para.Default = str2RealType(p[3], para.Type)
-					para.Required, _ = strconv.ParseBool(p[4])
-					paramDesc = strings.Trim(p[5], `" `)
-				default:
-					paramDesc = strings.Trim(p[3], `" `)
-				}
+				para.Required, _ = strconv.ParseBool(p[3])
+				para.AllowEmptyValue = !para.Required
+				paramDesc := strings.Trim(p[4], `" `)
 				lines := strings.Split(paramDesc, `\n`)
 				for _, line := range lines {
 					para.Description = fmt.Sprintf("%s\n%s", para.Description, line)
 				}
+
+				if len(p) >= 6 {
+					para.Default = str2RealType(p[5], para.Type)
+				}
+
+				if len(p) >= 7 {
+					values := strings.Split(p[6], ":")
+					if len(values) > 0 {
+						para.Enum = make([]interface{}, 0, len(values))
+					}
+					for _, value := range values {
+						para.Enum = append(para.Enum, value)
+					}
+				}
+
 				opts.Parameters = append(opts.Parameters, para)
 			} else if strings.HasPrefix(t, "@Failure") {
 				rs := swagger.Response{}

--- a/generate/swaggergen/swagger/swagger.go
+++ b/generate/swaggergen/swagger/swagger.go
@@ -70,15 +70,17 @@ type Operation struct {
 
 // Parameter Describes a single operation parameter.
 type Parameter struct {
-	In          string          `json:"in,omitempty" yaml:"in,omitempty"`
-	Name        string          `json:"name,omitempty" yaml:"name,omitempty"`
-	Description string          `json:"description,omitempty" yaml:"description,omitempty"`
-	Required    bool            `json:"required,omitempty" yaml:"required,omitempty"`
-	Schema      *Schema         `json:"schema,omitempty" yaml:"schema,omitempty"`
-	Type        string          `json:"type,omitempty" yaml:"type,omitempty"`
-	Format      string          `json:"format,omitempty" yaml:"format,omitempty"`
-	Items       *ParameterItems `json:"items,omitempty" yaml:"items,omitempty"`
-	Default     interface{}     `json:"default,omitempty" yaml:"default,omitempty"`
+	In              string          `json:"in,omitempty" yaml:"in,omitempty"`
+	Name            string          `json:"name,omitempty" yaml:"name,omitempty"`
+	Description     string          `json:"description,omitempty" yaml:"description,omitempty"`
+	Required        bool            `json:"required,omitempty" yaml:"required,omitempty"`
+	Schema          *Schema         `json:"schema,omitempty" yaml:"schema,omitempty"`
+	Type            string          `json:"type,omitempty" yaml:"type,omitempty"`
+	Format          string          `json:"format,omitempty" yaml:"format,omitempty"`
+	Items           *ParameterItems `json:"items,omitempty" yaml:"items,omitempty"`
+	AllowEmptyValue bool            `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
+	Default         interface{}     `json:"default,omitempty" yaml:"default,omitempty"`
+	Enum            []interface{}   `json:"enum,omitempty" yaml:"enum,omitempty"`
 }
 
 // ParameterItems A limited subset of JSON-Schema's items object. It is used by parameter definitions that are not located in "body".


### PR DESCRIPTION
* default 값을 [spec](https://beego.me/blog/beego_api)에 맞게 6번째에 파싱
* enum 타입 추가
   * enum은 무조건 default 있어야함
```go
// @Param [name] [type] [datatype] [required] [description] [default:optional] [enum:optional]
```
* 예제: `/api/v1/search/{target}`
  * /api/v1/search/
  * /api/v1/search/car
  * /api/v1/search/bike
```go
// @Param target path string false "search type" "car" "":"car":"bike"
```